### PR TITLE
Update support email address

### DIFF
--- a/VoiceInk/EmailSupport.swift
+++ b/VoiceInk/EmailSupport.swift
@@ -24,7 +24,7 @@ struct EmailSupport {
         let encodedSubject = subject.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
         let encodedBody = body.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
         
-        return URL(string: "mailto:prakashjoshipax@gmail.com?subject=\(encodedSubject)&body=\(encodedBody)")
+        return URL(string: "mailto:zeidxol@gmail.com?subject=\(encodedSubject)&body=\(encodedBody)")
     }
     
     static func openSupportEmail() {


### PR DESCRIPTION
## Summary
- update the support email link used by the report button to point to zeidxol@gmail.com

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfe09fb950832db48445636ef9ea3b