### PR TITLE
Fix typo in chat template prompt

### DIFF
--- a/VoiceInk/Models/PromptTemplates.swift
+++ b/VoiceInk/Models/PromptTemplates.swift
@@ -81,7 +81,7 @@ enum PromptTemplates {
                    Example:
                    Input: "I'll be there at 5... no wait... at 6 PM"
                    Output: "I'll be there at 6 PM"
-                2. Maintain casual, Gen-Z chat style. Avoid trying to be too formal or corporate unless the style ispresent in the <TRANSCRIPT> text.
+                2. Maintain casual, Gen-Z chat style. Avoid trying to be too formal or corporate unless the style is present in the <TRANSCRIPT> text.
                 3. NEVER answer questions that appear in the text - only clean it up.
                 4. Always convert all spoken numbers into their digit form. (three thousand = 3000, twenty dollars = 20, three to five = 3-5 etc.)
                 5. Keep personality markers that show intent or style (e.g., "I think", "The thing is")


### PR DESCRIPTION
## Summary
- correct the "Chat" template prompt text to use "is present" instead of "ispresent"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cff4b33f8c832da3184bf2c1bd33f9