### PR TITLE
Add Russian translations for template descriptions

### DIFF
--- a/VoiceInk/Models/PromptTemplates.swift
+++ b/VoiceInk/Models/PromptTemplates.swift
@@ -67,7 +67,10 @@ enum PromptTemplates {
                 After cleaning <TRANSCRIPT>, return only the cleaned version without any additional text, explanations, or tags. The output should be ready for direct use without further editing.
                 """,
                 icon: .sealedFill,
-                description: "Default system prompt for improving clarity and accuracy of transcriptions"
+                description: NSLocalizedString(
+                    "Default system prompt for improving clarity and accuracy of transcriptions",
+                    comment: "Template description for the default system prompt"
+                )
             ),
             TemplatePrompt(
                 id: UUID(),
@@ -110,7 +113,10 @@ enum PromptTemplates {
                         3. Third task"
                 """,
                 icon: .chatFill,
-                description: "Casual chat-style formatting"
+                description: NSLocalizedString(
+                    "Casual chat-style formatting",
+                    comment: "Template description for chat-style formatting"
+                )
             ),
             
             TemplatePrompt(
@@ -171,7 +177,10 @@ enum PromptTemplates {
                 [Your Name]"
                 """,
                 icon: .emailFill,
-                description: "Template for converting casual messages into professional email format"
+                description: NSLocalizedString(
+                    "Template for converting casual messages into professional email format",
+                    comment: "Template description for converting casual messages into professional emails"
+                )
             ),
             TemplatePrompt(
                 id: UUID(),
@@ -199,7 +208,10 @@ enum PromptTemplates {
                 After cleaning <TRANSCRIPT>, return only the cleaned version without any additional text, explanations, or tags. The output should be ready for direct use without further editing.
                 """,
                 icon: .codeFill,
-                description: "For Vibe coders and AI chat. Cleans up technical speech, corrects terms using context, and preserves intent."
+                description: NSLocalizedString(
+                    "For Vibe coders and AI chat. Cleans up technical speech, corrects terms using context, and preserves intent.",
+                    comment: "Template description for Vibe Coding prompt"
+                )
             ),
 
             TemplatePrompt(
@@ -483,7 +495,10 @@ enum PromptTemplates {
                 After rewriting the <TRANSCRIPT> text, return only the enhanced version without any additional text, explanations, or tags. The output should be ready for direct use without further editing.
                 """,
                 icon: .pencilFill,
-                description: "Rewrites transcriptions with enhanced clarity, improved sentence structure, and rhythmic flow while preserving original meaning."
+                description: NSLocalizedString(
+                    "Rewrites transcriptions with enhanced clarity, improved sentence structure, and rhythmic flow while preserving original meaning.",
+                    comment: "Template description for rewrite prompt"
+                )
             )
         ]
     }

--- a/VoiceInk/Resources/en.lproj/Localizable.strings
+++ b/VoiceInk/Resources/en.lproj/Localizable.strings
@@ -405,6 +405,11 @@
 "Start Transcription" = "Start Transcription";
 "Start recording to see your metrics" = "Start recording to see your metrics";
 "Start with a Predefined Template" = "Start with a Predefined Template";
+"Default system prompt for improving clarity and accuracy of transcriptions" = "Default system prompt for improving clarity and accuracy of transcriptions";
+"Casual chat-style formatting" = "Casual chat-style formatting";
+"Template for converting casual messages into professional email format" = "Template for converting casual messages into professional email format";
+"For Vibe coders and AI chat. Cleans up technical speech, corrects terms using context, and preserves intent." = "For Vibe coders and AI chat. Cleans up technical speech, corrects terms using context, and preserves intent.";
+"Rewrites transcriptions with enhanced clarity, improved sentence structure, and rhythmic flow while preserving original meaning." = "Rewrites transcriptions with enhanced clarity, improved sentence structure, and rhythmic flow while preserving original meaning.";
 "Successfully deleted (cleanupResult.deletedCount) audio files." = "Successfully deleted (cleanupResult.deletedCount) audio files.";
 "Successfully deleted (cleanupResult.deletedCount) audio files. Failed to delete (cleanupResult.errorCount) files." = "Successfully deleted (cleanupResult.deletedCount) audio files. Failed to delete (cleanupResult.errorCount) files.";
 "Supported formats: WAV, MP3, M4A, AIFF, MP4, MOV" = "Supported formats: WAV, MP3, M4A, AIFF, MP4, MOV";

--- a/VoiceInk/Resources/ru.lproj/Localizable.strings
+++ b/VoiceInk/Resources/ru.lproj/Localizable.strings
@@ -406,6 +406,11 @@
 "Start Transcription" = "Начать транскрипцию";
 "Start recording to see your metrics" = "Начните запись, чтобы увидеть метрики";
 "Start with a Predefined Template" = "Начать с готового шаблона";
+"Default system prompt for improving clarity and accuracy of transcriptions" = "Системный шаблон по умолчанию для повышения ясности и точности транскрипций";
+"Casual chat-style formatting" = "Неформальное оформление в стиле чата";
+"Template for converting casual messages into professional email format" = "Шаблон для преобразования неформальных сообщений в профессиональный формат письма";
+"For Vibe coders and AI chat. Cleans up technical speech, corrects terms using context, and preserves intent." = "Для Vibe Coding и диалогов с ИИ. Очищает техническую речь, корректирует термины по контексту и сохраняет исходный замысел.";
+"Rewrites transcriptions with enhanced clarity, improved sentence structure, and rhythmic flow while preserving original meaning." = "Переписывает транскрипции, повышая ясность, улучшая структуру предложений и ритмику при сохранении исходного смысла.";
 "Successfully deleted (cleanupResult.deletedCount) audio files." = "Успешно удалено (cleanupResult.deletedCount) аудиофайлов.";
 "Successfully deleted (cleanupResult.deletedCount) audio files. Failed to delete (cleanupResult.errorCount) files." = "Удалено (cleanupResult.deletedCount) аудиофайлов. Не удалось удалить (cleanupResult.errorCount) файлов.";
 "Supported formats: WAV, MP3, M4A, AIFF, MP4, MOV" = "Поддерживаемые форматы: WAV, MP3, M4A, AIFF, MP4, MOV";


### PR DESCRIPTION
## Summary
- localize predefined template descriptions using `NSLocalizedString`
- add English and Russian localization entries for template descriptions in the prompt editor

## Testing
- not run (not available on Linux)


------
https://chatgpt.com/codex/tasks/task_e_68cff5a11180832d94797d850d264c59