### PR TITLE
Prevent collapsing the sidebar

### DIFF
--- a/VoiceInk/Views/ContentView.swift
+++ b/VoiceInk/Views/ContentView.swift
@@ -167,8 +167,8 @@ struct ContentView: View {
                 selectedView: $selectedView,
                 hoveredView: $hoveredView
             )
-            .frame(width: 200)
-            .navigationSplitViewColumnWidth(200)
+            .frame(minWidth: 200, idealWidth: 200)
+            .navigationSplitViewColumnWidth(min: 200, ideal: 200)
         } detail: {
             detailView
                 .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
## Summary
- enforce a minimum width for the navigation sidebar
- prevent the sidebar column from collapsing when dragged

## Testing
- not run (requires Xcode, unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cffbd78f14832d80b3ed784e33d65f