### PR TITLE
Fix localization bundle switching and time formatter locales

### DIFF
--- a/VoiceInk/Localization/Bundle+Localization.swift
+++ b/VoiceInk/Localization/Bundle+Localization.swift
@@ -1,0 +1,33 @@
+import Foundation
+import ObjectiveC.runtime
+
+private var associatedBundleKey: UInt8 = 0
+
+private final class LocalizedBundle: Bundle {
+    override func localizedString(forKey key: String, value: String?, table tableName: String?) -> String {
+        if let bundle = objc_getAssociatedObject(self, &associatedBundleKey) as? Bundle {
+            return bundle.localizedString(forKey: key, value: value, table: tableName)
+        }
+        return super.localizedString(forKey: key, value: value, table: tableName)
+    }
+}
+
+private let swizzleLocalizationBundle: Void = {
+    object_setClass(Bundle.main, LocalizedBundle.self)
+}()
+
+extension Bundle {
+    static func setLanguage(_ languageCode: String) {
+        _ = swizzleLocalizationBundle
+
+        guard
+            let path = Bundle.main.path(forResource: languageCode, ofType: "lproj"),
+            let bundle = Bundle(path: path)
+        else {
+            objc_setAssociatedObject(Bundle.main, &associatedBundleKey, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            return
+        }
+
+        objc_setAssociatedObject(Bundle.main, &associatedBundleKey, bundle, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+}

--- a/VoiceInk/Localization/LanguageManager.swift
+++ b/VoiceInk/Localization/LanguageManager.swift
@@ -27,7 +27,8 @@ final class LanguageManager: ObservableObject {
 
     @Published var selectedLanguage: AppLanguage {
         didSet {
-            UserDefaults.standard.set(selectedLanguage.rawValue, forKey: Constants.storageKey)
+            persistLanguageSelection()
+            Bundle.setLanguage(selectedLanguage.rawValue)
             NotificationCenter.default.post(name: .languageDidChange, object: selectedLanguage)
         }
     }
@@ -39,10 +40,17 @@ final class LanguageManager: ObservableObject {
         } else {
             selectedLanguage = .english
         }
+
+        Bundle.setLanguage(selectedLanguage.rawValue)
         NotificationCenter.default.post(name: .languageDidChange, object: selectedLanguage)
     }
 
     var locale: Locale {
         selectedLanguage.locale
     }
+
+    private func persistLanguageSelection() {
+        UserDefaults.standard.set(selectedLanguage.rawValue, forKey: Constants.storageKey)
+    }
+
 }

--- a/VoiceInk/Views/Metrics/PerformanceAnalysisView.swift
+++ b/VoiceInk/Views/Metrics/PerformanceAnalysisView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct PerformanceAnalysisView: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.locale) private var locale
     let transcriptions: [Transcription]
     private let analysis: AnalysisResult
 
@@ -126,6 +127,7 @@ struct PerformanceAnalysisView: View {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.minute, .second]
         formatter.unitsStyle = .abbreviated
+        formatter.locale = locale
         return formatter.string(from: duration) ?? "0s"
     }
 
@@ -313,6 +315,7 @@ struct SystemInfoCard: View {
 
 struct TranscriptionModelCard: View {
     let modelStat: PerformanceAnalysisView.ModelStat
+    @Environment(\.locale) private var locale
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -372,6 +375,7 @@ struct TranscriptionModelCard: View {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.minute, .second]
         formatter.unitsStyle = .abbreviated
+        formatter.locale = locale
         return formatter.string(from: duration) ?? "0s"
     }
 }

--- a/VoiceInk/Views/Metrics/TimeEfficiencyView.swift
+++ b/VoiceInk/Views/Metrics/TimeEfficiencyView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct TimeEfficiencyView: View {
+    @Environment(\.locale) private var locale
     // MARK: - Properties
     
     private let totalRecordedTime: TimeInterval
@@ -175,6 +176,7 @@ struct TimeEfficiencyView: View {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.hour, .minute, .second]
         formatter.unitsStyle = .abbreviated
+        formatter.locale = locale
         return formatter.string(from: duration) ?? ""
     }
 }
@@ -182,6 +184,7 @@ struct TimeEfficiencyView: View {
 // MARK: - Helper Struct
 
 struct TimeBlockView: View {
+    @Environment(\.locale) private var locale
     let duration: TimeInterval
     let label: LocalizedStringKey
     let icon: String
@@ -191,6 +194,7 @@ struct TimeBlockView: View {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.hour, .minute, .second]
         formatter.unitsStyle = .abbreviated
+        formatter.locale = locale
         return formatter.string(from: duration) ?? ""
     }
     


### PR DESCRIPTION
## Summary
- add a localization bundle override so manual language changes affect `String(localized:)` and `NSLocalizedString`
- update the language manager to apply the bundle override when the selected language changes
- ensure dashboard time formatters respect the active locale for unit abbreviations

## Testing
- not run (macOS-only project in Linux CI environment)


------
https://chatgpt.com/codex/tasks/task_e_68cffb509434832d9252a0678e05a5b3