### PR TITLE
Fix DateComponentsFormatter locale usage

### DIFF
--- a/VoiceInk/Views/Metrics/TimeEfficiencyView.swift
+++ b/VoiceInk/Views/Metrics/TimeEfficiencyView.swift
@@ -176,7 +176,9 @@ struct TimeEfficiencyView: View {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.hour, .minute, .second]
         formatter.unitsStyle = .abbreviated
-        formatter.locale = locale
+        var calendar = Calendar.current
+        calendar.locale = locale
+        formatter.calendar = calendar
         return formatter.string(from: duration) ?? ""
     }
 }
@@ -194,7 +196,9 @@ struct TimeBlockView: View {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.hour, .minute, .second]
         formatter.unitsStyle = .abbreviated
-        formatter.locale = locale
+        var calendar = Calendar.current
+        calendar.locale = locale
+        formatter.calendar = calendar
         return formatter.string(from: duration) ?? ""
     }
     


### PR DESCRIPTION
## Summary
- update TimeEfficiencyView duration formatter configuration to apply the environment locale via Calendar

## Testing
- not run (macOS build tools unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d004ccbbe8832d972d2b51ecc310a4