### PR TITLE
Fix locale handling in performance metrics views

### DIFF
--- a/VoiceInk/Views/Metrics/PerformanceAnalysisView.swift
+++ b/VoiceInk/Views/Metrics/PerformanceAnalysisView.swift
@@ -127,7 +127,9 @@ struct PerformanceAnalysisView: View {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.minute, .second]
         formatter.unitsStyle = .abbreviated
-        formatter.locale = locale
+        var calendar = Calendar.current
+        calendar.locale = locale
+        formatter.calendar = calendar
         return formatter.string(from: duration) ?? "0s"
     }
 
@@ -375,7 +377,9 @@ struct TranscriptionModelCard: View {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.minute, .second]
         formatter.unitsStyle = .abbreviated
-        formatter.locale = locale
+        var calendar = Calendar.current
+        calendar.locale = locale
+        formatter.calendar = calendar
         return formatter.string(from: duration) ?? "0s"
     }
 }


### PR DESCRIPTION
## Summary
- replace unavailable DateComponentsFormatter.locale usage with calendar locale configuration
- ensure performance metrics duration formatting respects the current locale without build errors

## Testing
- not run (not available on this platform)


------
https://chatgpt.com/codex/tasks/task_e_68d005729aa4832dae833e368603ccc0