### PR TITLE
Fix DateComponentsFormatter locale usage

### DIFF
--- a/VoiceInk/Views/Metrics/PerformanceAnalysisView.swift
+++ b/VoiceInk/Views/Metrics/PerformanceAnalysisView.swift
@@ -127,7 +127,9 @@ struct PerformanceAnalysisView: View {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.minute, .second]
         formatter.unitsStyle = .abbreviated
-        formatter.locale = locale
+        var calendar = Calendar.current
+        calendar.locale = locale
+        formatter.calendar = calendar
         return formatter.string(from: duration) ?? "0s"
     }
 
@@ -375,7 +377,9 @@ struct TranscriptionModelCard: View {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.minute, .second]
         formatter.unitsStyle = .abbreviated
-        formatter.locale = locale
+        var calendar = Calendar.current
+        calendar.locale = locale
+        formatter.calendar = calendar
         return formatter.string(from: duration) ?? "0s"
     }
 }

--- a/VoiceInk/Views/Metrics/TimeEfficiencyView.swift
+++ b/VoiceInk/Views/Metrics/TimeEfficiencyView.swift
@@ -176,7 +176,9 @@ struct TimeEfficiencyView: View {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.hour, .minute, .second]
         formatter.unitsStyle = .abbreviated
-        formatter.locale = languageManager.locale
+        var calendar = Calendar.current
+        calendar.locale = languageManager.locale
+        formatter.calendar = calendar
         return formatter.string(from: duration) ?? ""
     }
 }
@@ -194,7 +196,9 @@ struct TimeBlockView: View {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.hour, .minute, .second]
         formatter.unitsStyle = .abbreviated
-        formatter.locale = languageManager.locale
+        var calendar = Calendar.current
+        calendar.locale = languageManager.locale
+        formatter.calendar = calendar
         return formatter.string(from: duration) ?? ""
     }
     


### PR DESCRIPTION
## Summary
- configure DateComponentsFormatter instances via Calendar.locale instead of the unavailable locale property
- apply the same change to all metrics views that format durations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0110c97d4832db7eec3e80f3e5bae