### PR TITLE
Fix support email localization and export panel

### DIFF
--- a/VoiceInk/EmailSupport.swift
+++ b/VoiceInk/EmailSupport.swift
@@ -4,10 +4,14 @@ import AppKit
 
 struct EmailSupport {
     static func generateSupportEmailURL() -> URL? {
-        let subject = String(localized: "support.email.subject")
+        let languageManager = LanguageManager.shared
+
+        let subject = languageManager.localizedString(for: "support.email.subject")
+
+        let systemInfoFormat = languageManager.localizedString(for: "support.email.systemInfo")
         let systemInfo = String(
-            format: String(localized: "support.email.systemInfo"),
-            locale: Locale.current,
+            format: systemInfoFormat,
+            locale: languageManager.locale,
             Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown",
             ProcessInfo.processInfo.operatingSystemVersionString,
             getMacModel(),
@@ -15,12 +19,13 @@ struct EmailSupport {
             getMemoryInfo()
         )
 
+        let bodyFormat = languageManager.localizedString(for: "support.email.body")
         let body = String(
-            format: String(localized: "support.email.body"),
-            locale: Locale.current,
+            format: bodyFormat,
+            locale: languageManager.locale,
             systemInfo
         )
-        
+
         let encodedSubject = subject.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
         let encodedBody = body.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
         

--- a/VoiceInk/Resources/en.lproj/Localizable.strings
+++ b/VoiceInk/Resources/en.lproj/Localizable.strings
@@ -130,6 +130,7 @@
 "alerts.exportSettings.successMessage" = "Your settings have been successfully exported to %@.";
 "Import Error" = "Import Error";
 "alerts.exportSettings.writeError" = "Could not save settings to file: %@.";
+"alerts.exportSettings.missingURL" = "Could not determine a file location for your export.";
 "Import Successful" = "Import Successful";
 "Save Transcription" = "Save Transcription";
 "Select a Whisper ggml .bin model" = "Select a Whisper ggml .bin model";

--- a/VoiceInk/Resources/ru.lproj/Localizable.strings
+++ b/VoiceInk/Resources/ru.lproj/Localizable.strings
@@ -131,6 +131,7 @@
 "alerts.exportSettings.successMessage" = "Ваши настройки были успешно экспортированы в %@.";
 "Import Error" = "Ошибка импорта";
 "alerts.exportSettings.writeError" = "Не удалось сохранить настройки в файл: %@.";
+"alerts.exportSettings.missingURL" = "Не удалось определить путь для сохранения файла.";
 "Import Successful" = "Импорт выполнен успешно";
 "Save Transcription" = "Сохранить транскрипцию";
 "Select a Whisper ggml .bin model" = "Выберите модель Whisper ggml .bin";

--- a/VoiceInk/Services/ImportExportService.swift
+++ b/VoiceInk/Services/ImportExportService.swift
@@ -131,46 +131,49 @@ class ImportExportService {
             savePanel.title = languageManager.localizedString(for: "Export VoiceInk Settings")
             savePanel.message = languageManager.localizedString(for: "Choose a location to save your settings.")
 
-            DispatchQueue.main.async {
-                if savePanel.runModal() == .OK {
-                    if let url = savePanel.url {
-                        do {
-                            try jsonData.write(to: url)
-                            let messageFormat = languageManager.localizedString(
-                                for: "alerts.exportSettings.successMessage",
-                                defaultValue: "Your settings have been successfully exported to %@."
-                            )
-                            let message = String(
-                                format: messageFormat,
-                                locale: languageManager.locale,
-                                url.lastPathComponent
-                            )
-                            self.showAlert(
-                                title: languageManager.localizedString(for: "Export Successful"),
-                                message: message
-                            )
-                        } catch {
-                            let messageFormat = languageManager.localizedString(
-                                for: "alerts.exportSettings.writeError",
-                                defaultValue: "Could not save settings to file: %@."
-                            )
-                            let message = String(
-                                format: messageFormat,
-                                locale: languageManager.locale,
-                                error.localizedDescription
-                            )
-                            self.showAlert(
-                                title: languageManager.localizedString(for: "Export Error"),
-                                message: message
-                            )
-                        }
+            if savePanel.runModal() == .OK {
+                if let url = savePanel.url {
+                    do {
+                        try jsonData.write(to: url)
+                        let messageFormat = languageManager.localizedString(
+                            for: "alerts.exportSettings.successMessage",
+                            defaultValue: "Your settings have been successfully exported to %@."
+                        )
+                        let message = String(
+                            format: messageFormat,
+                            locale: languageManager.locale,
+                            url.lastPathComponent
+                        )
+                        self.showAlert(
+                            title: languageManager.localizedString(for: "Export Successful"),
+                            message: message
+                        )
+                    } catch {
+                        let messageFormat = languageManager.localizedString(
+                            for: "alerts.exportSettings.writeError",
+                            defaultValue: "Could not save settings to file: %@."
+                        )
+                        let message = String(
+                            format: messageFormat,
+                            locale: languageManager.locale,
+                            error.localizedDescription
+                        )
+                        self.showAlert(
+                            title: languageManager.localizedString(for: "Export Error"),
+                            message: message
+                        )
                     }
                 } else {
                     self.showAlert(
-                        title: languageManager.localizedString(for: "Export Canceled"),
-                        message: languageManager.localizedString(for: "The settings export operation was canceled.")
+                        title: languageManager.localizedString(for: "Export Error"),
+                        message: languageManager.localizedString(for: "alerts.exportSettings.missingURL", defaultValue: "Could not determine a file location for your export.")
                     )
                 }
+            } else {
+                self.showAlert(
+                    title: languageManager.localizedString(for: "Export Canceled"),
+                    message: languageManager.localizedString(for: "The settings export operation was canceled.")
+                )
             }
         } catch {
             let messageFormat = languageManager.localizedString(

--- a/VoiceInk/Whisper/WhisperPrompt.swift
+++ b/VoiceInk/Whisper/WhisperPrompt.swift
@@ -31,7 +31,7 @@ class WhisperPrompt: ObservableObject {
         "de": "Hallo, wie geht es dir? Schön dich kennenzulernen.",
         "it": "Ciao, come stai? Piacere di conoscerti.",
         "pt": "Olá, como você está? Prazer em conhecê-lo.",
-        "ru": "Здравствуйте, как ваши дела? Приятно познакомиться.",
+        "ru": "Hello, how are you doing? Nice to meet you.",
         "pl": "Cześć, jak się masz? Miło cię poznać.",
         "nl": "Hallo, hoe gaat het? Aangenaam kennis te maken.",
         "tr": "Merhaba, nasılsın? Tanıştığımıza memnun oldum.",


### PR DESCRIPTION
## Summary
- ensure the support email subject and body honor the in-app language selection
- keep the Output Format example in English even when Russian is selected
- run the export save panel synchronously on the main thread and handle missing URLs to avoid crashes

## Testing
- not run (macOS project requires Xcode)

------
https://chatgpt.com/codex/tasks/task_e_68d01574a44c832da01352bccfe8ac09