### PR TITLE
Set Russian as default app language

### DIFF
--- a/VoiceInk/Localization/LanguageManager.swift
+++ b/VoiceInk/Localization/LanguageManager.swift
@@ -40,7 +40,7 @@ final class LanguageManager: ObservableObject {
            let language = AppLanguage(rawValue: storedValue) {
             selectedLanguage = language
         } else {
-            selectedLanguage = .english
+            selectedLanguage = .russian
         }
 
         Bundle.setLanguage(selectedLanguage.rawValue)


### PR DESCRIPTION
## Summary
- set Russian as the default application language when no previous selection exists

## Testing
- not run (macOS project; tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d019f0905c832dbb23d0164114dad8