### PR TITLE
Fix export settings crash when opening save panel

### DIFF
--- a/VoiceInk/Services/ImportExportService.swift
+++ b/VoiceInk/Services/ImportExportService.swift
@@ -125,13 +125,13 @@ class ImportExportService {
         do {
             let jsonData = try encoder.encode(exportedSettings)
 
-            let savePanel = NSSavePanel()
-            savePanel.allowedContentTypes = [UTType.json]
-            savePanel.nameFieldStringValue = "VoiceInk_Settings_Backup.json"
-            savePanel.title = languageManager.localizedString(for: "Export VoiceInk Settings")
-            savePanel.message = languageManager.localizedString(for: "Choose a location to save your settings.")
-
             DispatchQueue.main.async {
+                let savePanel = NSSavePanel()
+                savePanel.allowedContentTypes = [UTType.json]
+                savePanel.nameFieldStringValue = "VoiceInk_Settings_Backup.json"
+                savePanel.title = languageManager.localizedString(for: "Export VoiceInk Settings")
+                savePanel.message = languageManager.localizedString(for: "Choose a location to save your settings.")
+
                 if savePanel.runModal() == .OK {
                     if let url = savePanel.url {
                         do {


### PR DESCRIPTION
## Summary
- ensure the settings export save panel is created on the main thread before being displayed

## Testing
- not run (not available in container environment)

------
https://chatgpt.com/codex/tasks/task_e_68d01ee05b24832db646bfbc22cd8ea0