### PR TITLE
Fix export settings crash by updating entitlements

### DIFF
--- a/VoiceInk/VoiceInk.entitlements
+++ b/VoiceInk/VoiceInk.entitlements
@@ -2,13 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.screen-capture</key>
-	<true/>
-	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
-	<array>
-		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>
-		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spki</string>
-	</array>
+        <key>com.apple.security.screen-capture</key>
+        <true/>
+        <key>com.apple.security.files.user-selected.read-write</key>
+        <true/>
+        <key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+        <array>
+                <string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>
+                <string>$(PRODUCT_BUNDLE_IDENTIFIER)-spki</string>
+        </array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)com.prakashjoshipax.VoiceInk</string>


### PR DESCRIPTION
## Summary
- add the User Selected File Read/Write entitlement so the app can present save panels

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d021f501fc832dae31543f0e934a72