### PR TITLE
Fix custom provider API key editing

### DIFF
--- a/VoiceInk/Views/AI Models/APIKeyManagementView.swift
+++ b/VoiceInk/Views/AI Models/APIKeyManagementView.swift
@@ -294,21 +294,9 @@ struct APIKeyManagementView: View {
                                 .font(.system(.body, design: .monospaced))
                                 .disabled(true)
                         } else {
-                            if apiKey.isEmpty {
-                                SecureField(
-                                    "API Key",
-                                    text: Binding(
-                                        get: { String(repeating: "•", count: max(aiService.apiKey.count, 8)) },
-                                        set: { apiKey = $0 }
-                                    )
-                                )
+                            SecureField("API Key", text: $apiKey)
                                 .textFieldStyle(.roundedBorder)
                                 .font(.system(.body, design: .monospaced))
-                            } else {
-                                SecureField("API Key", text: $apiKey)
-                                    .textFieldStyle(.roundedBorder)
-                                    .font(.system(.body, design: .monospaced))
-                            }
                         }
 
                         HStack {
@@ -509,6 +497,14 @@ struct APIKeyManagementView: View {
         .onChange(of: aiService.isAPIKeyValid) { oldValue, newValue in
             if !newValue {
                 isEditingCustomProvider = true
+            }
+        }
+        .onChange(of: isEditingCustomProvider) { _, newValue in
+            guard aiService.selectedProvider == .custom else { return }
+            if newValue {
+                apiKey = aiService.apiKey
+            } else {
+                apiKey = ""
             }
         }
         .onChange(of: providerTimeout) { _, newValue in


### PR DESCRIPTION
## Summary
- replace the custom provider API key placeholder binding with a regular secure field so the value can be cleared
- synchronize the editable field with the stored key whenever the custom provider editing mode toggles

## Testing
- xcodebuild -project VoiceInk.xcodeproj -scheme VoiceInk -sdk macosx build (fails: xcodebuild not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d02aa03318832da30563d9f536e6d1