### PR TITLE
Fix null selection counter in history toolbar

### DIFF
--- a/VoiceInk/Views/TranscriptionHistoryView.swift
+++ b/VoiceInk/Views/TranscriptionHistoryView.swift
@@ -412,8 +412,18 @@ struct TranscriptionHistoryView: View {
     }
     
     private func selectionCountText(for count: Int) -> String {
-        let format = NSLocalizedString("history.selectionCount", comment: "Selection count label in history toolbar")
-        return String.localizedStringWithFormat(format, count)
+        let languageManager = LanguageManager.shared
+        let format = languageManager.localizedString(
+            for: "history.selectionCount",
+            defaultValue: "%ld selected",
+            table: "Localizable"
+        )
+
+        if format.contains("%#@") {
+            return String.localizedStringWithFormat(format, count)
+        }
+
+        return String(format: format, locale: languageManager.locale, count)
     }
 
     private func deleteConfirmationMessage(for count: Int) -> String {


### PR DESCRIPTION
## Summary
- resolve the history selection toolbar showing `(null)` by using the shared LanguageManager to fetch the localized format
- format the selection counter with the active locale and handle pluralized resources safely

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d02cba24c0832db910394846a4cf91