### PR TITLE
Enable editing custom dictionary entries

### DIFF
--- a/VoiceInk/Resources/en.lproj/Localizable.strings
+++ b/VoiceInk/Resources/en.lproj/Localizable.strings
@@ -102,6 +102,10 @@
 "Correct Spellings" = "Correct Spellings";
 "Dictionary Items Count Format" = "Dictionary Items (%d)";
 "Dictionary duplicate word message" = "'%@' is already in the dictionary";
+"Dictionary empty word message" = "Word can't be empty";
+"Edit word" = "Edit word";
+"Save word" = "Save word";
+"Cancel editing" = "Cancel editing";
 "HotkeyOption.None" = "None";
 "HotkeyOption.RightOption" = "Right Option (⌥)";
 "HotkeyOption.LeftOption" = "Left Option (⌥)";

--- a/VoiceInk/Resources/ru.lproj/Localizable.strings
+++ b/VoiceInk/Resources/ru.lproj/Localizable.strings
@@ -102,6 +102,10 @@
 "Correct Spellings" = "Правильные написания";
 "Dictionary Items Count Format" = "Элементы словаря (%d)";
 "Dictionary duplicate word message" = "\"%@\" уже есть в словаре";
+"Dictionary empty word message" = "Слово не может быть пустым";
+"Edit word" = "Редактировать слово";
+"Save word" = "Сохранить слово";
+"Cancel editing" = "Отменить редактирование";
 "HotkeyOption.None" = "Нет";
 "HotkeyOption.RightOption" = "Правый Option (⌥)";
 "HotkeyOption.LeftOption" = "Левый Option (⌥)";


### PR DESCRIPTION
## Summary
- allow custom dictionary items to be edited inline via double-click or a new edit button
- add update validation in `DictionaryManager` and show localized alerts for duplicates and empty values
- localize helper strings for the new editing controls in English and Russian

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d033a70df8832db948ed610772d826