### PR TITLE
Improve localized string formatting support

### DIFF
--- a/VoiceInk/Localization/LanguageManager.swift
+++ b/VoiceInk/Localization/LanguageManager.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SwiftUI
 
 enum AppLanguage: String, CaseIterable, Identifiable {
@@ -67,10 +68,33 @@ final class LanguageManager: ObservableObject {
     }
 
     func localizedString(for key: String, defaultValue: String? = nil, table: String? = nil) -> String {
+        resolvedString(for: key, defaultValue: defaultValue, table: table)
+    }
+
+    func localizedString(
+        for key: String,
+        defaultValue: String? = nil,
+        table: String? = nil,
+        arguments: CVarArg...
+    ) -> String {
+        let format = resolvedString(for: key, defaultValue: defaultValue, table: table)
+        guard !arguments.isEmpty else { return format }
+        return formattedString(format, arguments: arguments)
+    }
+
+    private func resolvedString(for key: String, defaultValue: String?, table: String?) -> String {
         let fallback = defaultValue ?? key
         if let bundle = activeBundle {
             return bundle.localizedString(forKey: key, value: fallback, table: table)
         }
         return Bundle.main.localizedString(forKey: key, value: fallback, table: table)
+    }
+
+    private func formattedString(_ format: String, arguments: [CVarArg]) -> String {
+        let localeIdentifier = locale.identifier
+        let nsLocale = NSLocale(localeIdentifier: localeIdentifier)
+        return withVaList(arguments) { pointer in
+            NSString(format: format, locale: nsLocale, arguments: pointer) as String
+        }
     }
 }

--- a/VoiceInk/Services/ImportExportService.swift
+++ b/VoiceInk/Services/ImportExportService.swift
@@ -136,28 +136,20 @@ class ImportExportService {
                     if let url = savePanel.url {
                         do {
                             try jsonData.write(to: url)
-                            let messageFormat = languageManager.localizedString(
+                            let message = languageManager.localizedString(
                                 for: "alerts.exportSettings.successMessage",
-                                defaultValue: "Your settings have been successfully exported to %@."
-                            )
-                            let message = String(
-                                format: messageFormat,
-                                locale: languageManager.locale,
-                                url.lastPathComponent
+                                defaultValue: "Your settings have been successfully exported to %@.",
+                                arguments: url.lastPathComponent
                             )
                             self.showAlert(
                                 title: languageManager.localizedString(for: "Export Successful"),
                                 message: message
                             )
                         } catch {
-                            let messageFormat = languageManager.localizedString(
+                            let message = languageManager.localizedString(
                                 for: "alerts.exportSettings.writeError",
-                                defaultValue: "Could not save settings to file: %@."
-                            )
-                            let message = String(
-                                format: messageFormat,
-                                locale: languageManager.locale,
-                                error.localizedDescription
+                                defaultValue: "Could not save settings to file: %@.",
+                                arguments: error.localizedDescription
                             )
                             self.showAlert(
                                 title: languageManager.localizedString(for: "Export Error"),
@@ -173,14 +165,10 @@ class ImportExportService {
                 }
             }
         } catch {
-            let messageFormat = languageManager.localizedString(
+            let message = languageManager.localizedString(
                 for: "alerts.exportSettings.encodeError",
-                defaultValue: "Could not encode settings to JSON: %@."
-            )
-            let message = String(
-                format: messageFormat,
-                locale: languageManager.locale,
-                error.localizedDescription
+                defaultValue: "Could not encode settings to JSON: %@.",
+                arguments: error.localizedDescription
             )
             self.showAlert(title: languageManager.localizedString(for: "Export Error"), message: message)
         }
@@ -213,14 +201,10 @@ class ImportExportService {
                     let importedSettings = try decoder.decode(VoiceInkExportedSettings.self, from: jsonData)
 
                     if importedSettings.version != self.currentSettingsVersion {
-                        let messageFormat = languageManager.localizedString(
+                        let message = languageManager.localizedString(
                             for: "alerts.importSettings.versionMismatch",
-                            defaultValue: "The imported settings file (version %@) is from a different version than your application (version %@). Proceeding with import, but be aware of potential incompatibilities."
-                        )
-                        let message = String(
-                            format: messageFormat,
-                            locale: languageManager.locale,
-                            importedSettings.version,
+                            defaultValue: "The imported settings file (version %@) is from a different version than your application (version %@). Proceeding with import, but be aware of potential incompatibilities.",
+                            arguments: importedSettings.version,
                             self.currentSettingsVersion
                         )
                         self.showAlert(title: languageManager.localizedString(for: "Version Mismatch"), message: message)
@@ -332,14 +316,10 @@ class ImportExportService {
                     self.showRestartAlert(importedFileName: url.lastPathComponent)
 
                 } catch {
-                    let messageFormat = languageManager.localizedString(
+                    let message = languageManager.localizedString(
                         for: "alerts.importSettings.generalError",
-                        defaultValue: "Error importing settings: %@. The file might be corrupted or not in the correct format."
-                    )
-                    let message = String(
-                        format: messageFormat,
-                        locale: languageManager.locale,
-                        error.localizedDescription
+                        defaultValue: "Error importing settings: %@. The file might be corrupted or not in the correct format.",
+                        arguments: error.localizedDescription
                     )
                     self.showAlert(title: languageManager.localizedString(for: "Import Error"), message: message)
                 }
@@ -368,14 +348,10 @@ class ImportExportService {
             let alert = NSAlert()
             let languageManager = LanguageManager.shared
             alert.messageText = languageManager.localizedString(for: "Import Successful")
-            let successFormat = languageManager.localizedString(
+            let successMessage = languageManager.localizedString(
                 for: "alerts.importSettings.successMessage",
-                defaultValue: "Settings imported successfully from %@. All settings (including general app settings) have been applied."
-            )
-            let successMessage = String(
-                format: successFormat,
-                locale: languageManager.locale,
-                importedFileName
+                defaultValue: "Settings imported successfully from %@. All settings (including general app settings) have been applied.",
+                arguments: importedFileName
             )
             let reconfigureMessage = languageManager.localizedString(for: "alerts.importSettings.reconfigure")
             let restartMessage = languageManager.localizedString(for: "alerts.importSettings.restartRecommendation")

--- a/VoiceInk/Views/AI Models/APIKeyManagementView.swift
+++ b/VoiceInk/Views/AI Models/APIKeyManagementView.swift
@@ -465,11 +465,12 @@ struct APIKeyManagementView: View {
                         }
 
                         Stepper(value: $providerAttempts, in: 1...10) {
-                            let format = languageManager.localizedString(
+                            let text = languageManager.localizedString(
                                 for: "enhancement.maxAttempts",
-                                defaultValue: "Max attempts: %d"
+                                defaultValue: "Max attempts: %d",
+                                arguments: providerAttempts
                             )
-                            Text(String(format: format, locale: languageManager.locale, providerAttempts))
+                            Text(text)
                         }
 
                         Text("Each attempt times out after interval × remaining attempts.")

--- a/VoiceInk/Views/AI Models/LanguageSelectionView.swift
+++ b/VoiceInk/Views/AI Models/LanguageSelectionView.swift
@@ -207,10 +207,10 @@ struct LanguageSelectionView: View {
     }
 
     private func localizedCurrentModelText(_ displayName: String) -> String {
-        let format = languageManager.localizedString(
+        languageManager.localizedString(
             for: "models.currentModel",
-            defaultValue: "Current model: %@"
+            defaultValue: "Current model: %@",
+            arguments: displayName
         )
-        return String(format: format, locale: languageManager.locale, displayName)
     }
 }

--- a/VoiceInk/Views/Dictionary/DictionaryView.swift
+++ b/VoiceInk/Views/Dictionary/DictionaryView.swift
@@ -128,17 +128,12 @@ struct DictionaryView: View {
             // Words List
             if !dictionaryManager.items.isEmpty {
                 VStack(alignment: .leading, spacing: 12) {
-                    let format = languageManager.localizedString(
+                    let countText = languageManager.localizedString(
                         for: "Dictionary Items Count Format",
-                        defaultValue: "Dictionary Items (%d)"
+                        defaultValue: "Dictionary Items (%d)",
+                        arguments: dictionaryManager.items.count
                     )
-                    Text(
-                        String(
-                            format: format,
-                            locale: languageManager.locale,
-                            dictionaryManager.items.count
-                        )
-                    )
+                    Text(countText)
                         .font(.system(size: 12, weight: .medium))
                         .foregroundColor(.secondary)
                     
@@ -182,11 +177,11 @@ struct DictionaryView: View {
         
         if parts.count == 1, let word = parts.first {
             if dictionaryManager.items.contains(where: { $0.word.lowercased() == word.lowercased() }) {
-                let format = languageManager.localizedString(
+                alertMessage = languageManager.localizedString(
                     for: "Dictionary duplicate word message",
-                    defaultValue: "'%@' is already in the dictionary"
+                    defaultValue: "'%@' is already in the dictionary",
+                    arguments: word
                 )
-                alertMessage = String(format: format, locale: languageManager.locale, word)
                 showAlert = true
                 return
             }

--- a/VoiceInk/Views/TranscriptionHistoryView.swift
+++ b/VoiceInk/Views/TranscriptionHistoryView.swift
@@ -412,23 +412,21 @@ struct TranscriptionHistoryView: View {
     }
     
     private func selectionCountText(for count: Int) -> String {
-        let languageManager = LanguageManager.shared
-        let format = languageManager.localizedString(
+        LanguageManager.shared.localizedString(
             for: "history.selectionCount",
             defaultValue: "%ld selected",
-            table: "Localizable"
+            table: "Localizable",
+            arguments: count
         )
-
-        if format.contains("%#@") {
-            return String.localizedStringWithFormat(format, count)
-        }
-
-        return String(format: format, locale: languageManager.locale, count)
     }
 
     private func deleteConfirmationMessage(for count: Int) -> String {
-        let format = NSLocalizedString("history.deleteConfirmationMessage", comment: "Delete confirmation prompt in history section")
-        return String.localizedStringWithFormat(format, count)
+        LanguageManager.shared.localizedString(
+            for: "history.deleteConfirmationMessage",
+            defaultValue: "This action cannot be undone. Are you sure you want to delete %ld items?",
+            table: "Localizable",
+            arguments: count
+        )
     }
     
     private func toggleSelection(_ transcription: Transcription) {


### PR DESCRIPTION
## Summary
- add a varargs overload to `LanguageManager.localizedString` that formats templates using the active locale
- refactor views and services to use the helper for plural strings and other formatted messages
- ensure history prompts and alerts resolve correctly when plural rules are involved

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d0362d106c832db45fd07a4f57bb36