### PR TITLE
Fix localized strings with formatted arguments

### DIFF
--- a/VoiceInk/Localization/LanguageManager.swift
+++ b/VoiceInk/Localization/LanguageManager.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SwiftUI
 
 enum AppLanguage: String, CaseIterable, Identifiable {
@@ -72,5 +73,196 @@ final class LanguageManager: ObservableObject {
             return bundle.localizedString(forKey: key, value: fallback, table: table)
         }
         return Bundle.main.localizedString(forKey: key, value: fallback, table: table)
+    }
+
+    func localizedString(
+        for key: String,
+        defaultValue: String? = nil,
+        table: String? = nil,
+        arguments: CVarArg...
+    ) -> String {
+        let format = localizedString(for: key, defaultValue: defaultValue, table: table)
+        guard !arguments.isEmpty else {
+            return format
+        }
+
+        return formattedString(
+            format: format,
+            key: key,
+            defaultValue: defaultValue,
+            table: table,
+            arguments: arguments
+        )
+    }
+
+    private func formattedString(
+        format: String,
+        key: String,
+        defaultValue: String?,
+        table: String?,
+        arguments: [CVarArg]
+    ) -> String {
+        if format.contains("%#@") {
+            if let localized = localizedStringFromStringsdict(
+                key: key,
+                table: table,
+                arguments: arguments
+            ) {
+                return localized
+            }
+
+            let fallbackFormat = defaultValue ?? format
+            return String(format: fallbackFormat, locale: locale, arguments: arguments)
+        }
+
+        return String(format: format, locale: locale, arguments: arguments)
+    }
+
+    private func localizedStringFromStringsdict(
+        key: String,
+        table: String?,
+        arguments: [CVarArg]
+    ) -> String? {
+        let tableName = table ?? "Localizable"
+        let bundle = activeBundle ?? Bundle.main
+
+        guard
+            let url = bundle.url(forResource: tableName, withExtension: "stringsdict"),
+            let dictionary = NSDictionary(contentsOf: url) as? [String: Any],
+            let entry = dictionary[key] as? [String: Any],
+            let formatKey = entry["NSStringLocalizedFormatKey"] as? String
+        else {
+            return nil
+        }
+
+        let placeholders = extractPlaceholderNames(from: formatKey)
+        guard placeholders.count == arguments.count else {
+            return nil
+        }
+
+        var result = formatKey
+        for (index, placeholder) in placeholders.enumerated() {
+            guard
+                let spec = entry[placeholder] as? [String: Any],
+                let replacement = formattedReplacement(
+                    for: arguments[index],
+                    spec: spec
+                )
+            else {
+                return nil
+            }
+
+            result = result.replacingOccurrences(
+                of: "%#@\(placeholder)@",
+                with: replacement
+            )
+        }
+
+        return result
+    }
+
+    private func formattedReplacement(for argument: CVarArg, spec: [String: Any]) -> String? {
+        guard let specType = spec["NSStringFormatSpecTypeKey"] as? String else {
+            return nil
+        }
+
+        switch specType {
+        case "NSStringPluralRuleType":
+            guard let count = integerValue(from: argument) else {
+                return nil
+            }
+
+            let category = pluralCategory(for: count)
+            let format = (spec[category] as? String) ?? (spec["other"] as? String)
+            guard let resolvedFormat = format else {
+                return nil
+            }
+
+            return String(format: resolvedFormat, locale: locale, arguments: [count])
+        default:
+            if let valueFormat = spec["NSStringFormatValueTypeKey"] as? String {
+                return String(format: valueFormat, locale: locale, arguments: [argument])
+            }
+            return nil
+        }
+    }
+
+    private func integerValue(from argument: CVarArg) -> Int? {
+        if let value = argument as? Int {
+            return value
+        }
+        if let value = argument as? Int8 {
+            return Int(value)
+        }
+        if let value = argument as? Int16 {
+            return Int(value)
+        }
+        if let value = argument as? Int32 {
+            return Int(value)
+        }
+        if let value = argument as? Int64 {
+            return Int(value)
+        }
+        if let value = argument as? UInt {
+            return Int(value)
+        }
+        if let value = argument as? UInt8 {
+            return Int(value)
+        }
+        if let value = argument as? UInt16 {
+            return Int(value)
+        }
+        if let value = argument as? UInt32 {
+            return Int(value)
+        }
+        if let value = argument as? UInt64 {
+            return Int(value)
+        }
+        if let number = argument as? NSNumber {
+            return number.intValue
+        }
+        return nil
+    }
+
+    private func pluralCategory(for count: Int) -> String {
+        let normalized = abs(count)
+
+        switch selectedLanguage {
+        case .english:
+            return normalized == 1 ? "one" : "other"
+        case .russian:
+            let mod10 = normalized % 10
+            let mod100 = normalized % 100
+
+            if mod10 == 1 && mod100 != 11 {
+                return "one"
+            }
+
+            if (2...4).contains(mod10) && !(12...14).contains(mod100) {
+                return "few"
+            }
+
+            if mod10 == 0 || (5...9).contains(mod10) || (11...14).contains(mod100) {
+                return "many"
+            }
+
+            return "other"
+        }
+    }
+
+    private func extractPlaceholderNames(from format: String) -> [String] {
+        guard
+            let regex = try? NSRegularExpression(pattern: "%#@([A-Za-z0-9_]+)@", options: [])
+        else {
+            return []
+        }
+
+        let range = NSRange(format.startIndex..<format.endIndex, in: format)
+        return regex.matches(in: format, options: [], range: range).compactMap { match -> String? in
+            guard let nameRange = Range(match.range(at: 1), in: format) else {
+                return nil
+            }
+            return String(format[nameRange])
+        }
     }
 }

--- a/VoiceInk/Services/ImportExportService.swift
+++ b/VoiceInk/Services/ImportExportService.swift
@@ -136,28 +136,20 @@ class ImportExportService {
                     if let url = savePanel.url {
                         do {
                             try jsonData.write(to: url)
-                            let messageFormat = languageManager.localizedString(
+                            let message = languageManager.localizedString(
                                 for: "alerts.exportSettings.successMessage",
-                                defaultValue: "Your settings have been successfully exported to %@."
-                            )
-                            let message = String(
-                                format: messageFormat,
-                                locale: languageManager.locale,
-                                url.lastPathComponent
+                                defaultValue: "Your settings have been successfully exported to %@.",
+                                arguments: url.lastPathComponent
                             )
                             self.showAlert(
                                 title: languageManager.localizedString(for: "Export Successful"),
                                 message: message
                             )
                         } catch {
-                            let messageFormat = languageManager.localizedString(
+                            let message = languageManager.localizedString(
                                 for: "alerts.exportSettings.writeError",
-                                defaultValue: "Could not save settings to file: %@."
-                            )
-                            let message = String(
-                                format: messageFormat,
-                                locale: languageManager.locale,
-                                error.localizedDescription
+                                defaultValue: "Could not save settings to file: %@.",
+                                arguments: error.localizedDescription
                             )
                             self.showAlert(
                                 title: languageManager.localizedString(for: "Export Error"),
@@ -173,14 +165,10 @@ class ImportExportService {
                 }
             }
         } catch {
-            let messageFormat = languageManager.localizedString(
+            let message = languageManager.localizedString(
                 for: "alerts.exportSettings.encodeError",
-                defaultValue: "Could not encode settings to JSON: %@."
-            )
-            let message = String(
-                format: messageFormat,
-                locale: languageManager.locale,
-                error.localizedDescription
+                defaultValue: "Could not encode settings to JSON: %@.",
+                arguments: error.localizedDescription
             )
             self.showAlert(title: languageManager.localizedString(for: "Export Error"), message: message)
         }
@@ -213,15 +201,10 @@ class ImportExportService {
                     let importedSettings = try decoder.decode(VoiceInkExportedSettings.self, from: jsonData)
 
                     if importedSettings.version != self.currentSettingsVersion {
-                        let messageFormat = languageManager.localizedString(
+                        let message = languageManager.localizedString(
                             for: "alerts.importSettings.versionMismatch",
-                            defaultValue: "The imported settings file (version %@) is from a different version than your application (version %@). Proceeding with import, but be aware of potential incompatibilities."
-                        )
-                        let message = String(
-                            format: messageFormat,
-                            locale: languageManager.locale,
-                            importedSettings.version,
-                            self.currentSettingsVersion
+                            defaultValue: "The imported settings file (version %@) is from a different version than your application (version %@). Proceeding with import, but be aware of potential incompatibilities.",
+                            arguments: importedSettings.version, self.currentSettingsVersion
                         )
                         self.showAlert(title: languageManager.localizedString(for: "Version Mismatch"), message: message)
                     }
@@ -332,14 +315,10 @@ class ImportExportService {
                     self.showRestartAlert(importedFileName: url.lastPathComponent)
 
                 } catch {
-                    let messageFormat = languageManager.localizedString(
+                    let message = languageManager.localizedString(
                         for: "alerts.importSettings.generalError",
-                        defaultValue: "Error importing settings: %@. The file might be corrupted or not in the correct format."
-                    )
-                    let message = String(
-                        format: messageFormat,
-                        locale: languageManager.locale,
-                        error.localizedDescription
+                        defaultValue: "Error importing settings: %@. The file might be corrupted or not in the correct format.",
+                        arguments: error.localizedDescription
                     )
                     self.showAlert(title: languageManager.localizedString(for: "Import Error"), message: message)
                 }
@@ -368,14 +347,10 @@ class ImportExportService {
             let alert = NSAlert()
             let languageManager = LanguageManager.shared
             alert.messageText = languageManager.localizedString(for: "Import Successful")
-            let successFormat = languageManager.localizedString(
+            let successMessage = languageManager.localizedString(
                 for: "alerts.importSettings.successMessage",
-                defaultValue: "Settings imported successfully from %@. All settings (including general app settings) have been applied."
-            )
-            let successMessage = String(
-                format: successFormat,
-                locale: languageManager.locale,
-                importedFileName
+                defaultValue: "Settings imported successfully from %@. All settings (including general app settings) have been applied.",
+                arguments: importedFileName
             )
             let reconfigureMessage = languageManager.localizedString(for: "alerts.importSettings.reconfigure")
             let restartMessage = languageManager.localizedString(for: "alerts.importSettings.restartRecommendation")

--- a/VoiceInk/Views/AI Models/APIKeyManagementView.swift
+++ b/VoiceInk/Views/AI Models/APIKeyManagementView.swift
@@ -465,11 +465,13 @@ struct APIKeyManagementView: View {
                         }
 
                         Stepper(value: $providerAttempts, in: 1...10) {
-                            let format = languageManager.localizedString(
-                                for: "enhancement.maxAttempts",
-                                defaultValue: "Max attempts: %d"
+                            Text(
+                                languageManager.localizedString(
+                                    for: "enhancement.maxAttempts",
+                                    defaultValue: "Max attempts: %d",
+                                    arguments: providerAttempts
+                                )
                             )
-                            Text(String(format: format, locale: languageManager.locale, providerAttempts))
                         }
 
                         Text("Each attempt times out after interval × remaining attempts.")

--- a/VoiceInk/Views/AI Models/LanguageSelectionView.swift
+++ b/VoiceInk/Views/AI Models/LanguageSelectionView.swift
@@ -207,10 +207,10 @@ struct LanguageSelectionView: View {
     }
 
     private func localizedCurrentModelText(_ displayName: String) -> String {
-        let format = languageManager.localizedString(
+        languageManager.localizedString(
             for: "models.currentModel",
-            defaultValue: "Current model: %@"
+            defaultValue: "Current model: %@",
+            arguments: displayName
         )
-        return String(format: format, locale: languageManager.locale, displayName)
     }
 }

--- a/VoiceInk/Views/Dictionary/DictionaryView.swift
+++ b/VoiceInk/Views/Dictionary/DictionaryView.swift
@@ -128,17 +128,12 @@ struct DictionaryView: View {
             // Words List
             if !dictionaryManager.items.isEmpty {
                 VStack(alignment: .leading, spacing: 12) {
-                    let format = languageManager.localizedString(
+                    let countText = languageManager.localizedString(
                         for: "Dictionary Items Count Format",
-                        defaultValue: "Dictionary Items (%d)"
+                        defaultValue: "Dictionary Items (%d)",
+                        arguments: dictionaryManager.items.count
                     )
-                    Text(
-                        String(
-                            format: format,
-                            locale: languageManager.locale,
-                            dictionaryManager.items.count
-                        )
-                    )
+                    Text(countText)
                         .font(.system(size: 12, weight: .medium))
                         .foregroundColor(.secondary)
                     
@@ -182,11 +177,11 @@ struct DictionaryView: View {
         
         if parts.count == 1, let word = parts.first {
             if dictionaryManager.items.contains(where: { $0.word.lowercased() == word.lowercased() }) {
-                let format = languageManager.localizedString(
+                alertMessage = languageManager.localizedString(
                     for: "Dictionary duplicate word message",
-                    defaultValue: "'%@' is already in the dictionary"
+                    defaultValue: "'%@' is already in the dictionary",
+                    arguments: word
                 )
-                alertMessage = String(format: format, locale: languageManager.locale, word)
                 showAlert = true
                 return
             }

--- a/VoiceInk/Views/TranscriptionHistoryView.swift
+++ b/VoiceInk/Views/TranscriptionHistoryView.swift
@@ -412,23 +412,21 @@ struct TranscriptionHistoryView: View {
     }
     
     private func selectionCountText(for count: Int) -> String {
-        let languageManager = LanguageManager.shared
-        let format = languageManager.localizedString(
+        LanguageManager.shared.localizedString(
             for: "history.selectionCount",
             defaultValue: "%ld selected",
-            table: "Localizable"
+            table: "Localizable",
+            arguments: count
         )
-
-        if format.contains("%#@") {
-            return String.localizedStringWithFormat(format, count)
-        }
-
-        return String(format: format, locale: languageManager.locale, count)
     }
 
     private func deleteConfirmationMessage(for count: Int) -> String {
-        let format = NSLocalizedString("history.deleteConfirmationMessage", comment: "Delete confirmation prompt in history section")
-        return String.localizedStringWithFormat(format, count)
+        LanguageManager.shared.localizedString(
+            for: "history.deleteConfirmationMessage",
+            defaultValue: "This action cannot be undone. Are you sure you want to delete %ld item(s)?",
+            table: "Localizable",
+            arguments: count
+        )
     }
     
     private func toggleSelection(_ transcription: Transcription) {


### PR DESCRIPTION
## Summary
- add a formatted localized string helper that reads plural rules from stringsdict files and applies the selected locale
- switch UI call sites that previously formatted strings manually to the centralized helper
- ensure import/export alerts build localized messages without returning null placeholders

## Testing
- Not run (not available on this platform)


------
https://chatgpt.com/codex/tasks/task_e_68d0362d106c832db45fd07a4f57bb36