### PR TITLE
Set Russian as default language

### DIFF
--- a/VoiceInk/Localization/LanguageManager.swift
+++ b/VoiceInk/Localization/LanguageManager.swift
@@ -41,7 +41,7 @@ final class LanguageManager: ObservableObject {
            let language = AppLanguage(rawValue: storedValue) {
             selectedLanguage = language
         } else {
-            selectedLanguage = .english
+            selectedLanguage = .russian
         }
 
         Bundle.setLanguage(selectedLanguage.rawValue)


### PR DESCRIPTION
## Summary
- set the default language selection to Russian when no stored preference is found

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d04aa27710832dbdd9d23182bb577d