### PR TITLE
Disable audio muting and cleanup features by default

### DIFF
--- a/VoiceInk/MediaController.swift
+++ b/VoiceInk/MediaController.swift
@@ -20,7 +20,7 @@ class MediaController: ObservableObject {
     private init() {
         // Set default if not already set
         if !UserDefaults.standard.contains(key: "isSystemMuteEnabled") {
-            UserDefaults.standard.set(true, forKey: "isSystemMuteEnabled")
+            UserDefaults.standard.set(false, forKey: "isSystemMuteEnabled")
         }
     }
     

--- a/VoiceInk/Views/Settings/AudioCleanupSettingsView.swift
+++ b/VoiceInk/Views/Settings/AudioCleanupSettingsView.swift
@@ -7,7 +7,7 @@ struct AudioCleanupSettingsView: View {
     // Audio cleanup settings
     @AppStorage("IsTranscriptionCleanupEnabled") private var isTranscriptionCleanupEnabled = false
     @AppStorage("TranscriptionRetentionMinutes") private var transcriptionRetentionMinutes = 24 * 60
-    @AppStorage("IsAudioCleanupEnabled") private var isAudioCleanupEnabled = true
+    @AppStorage("IsAudioCleanupEnabled") private var isAudioCleanupEnabled = false
     @AppStorage("AudioRetentionPeriod") private var audioRetentionPeriod = 7
     @State private var isPerformingCleanup = false
     @State private var isShowingConfirmation = false


### PR DESCRIPTION
## Summary
- default the system audio muting preference to off for new installations
- default the automatic audio cleanup setting to off so cleanup does not run until enabled

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0ee513174832da24fd8583972433d