### PR TITLE
Localize transcription progress messages

### DIFF
--- a/VoiceInk/Resources/en.lproj/Localizable.strings
+++ b/VoiceInk/Resources/en.lproj/Localizable.strings
@@ -584,5 +584,10 @@
 "support.email.body" = "\n------------------------\n✨ **SCREEN RECORDING HIGHLY RECOMMENDED** ✨\n▶️ Create a quick screen recording showing the issue!\n▶️ It helps me understand and fix the problem much faster.\n\n📝 ISSUE DETAILS:\n- What steps did you take before the issue occurred?\n- What did you expect to happen?\n- What actually happened instead?\n\n\n## 📋 COMMON ISSUES:\nCheck out our Common Issues page before sending an email: https://tryvoiceink.com/common-issues\n------------------------\n\nSystem Information:\n%@\n\n";
 "support.email.subject" = "VoiceInk Support Request";
 "support.email.systemInfo" = "App Version: %@\nmacOS Version: %@\nDevice: %@\nCPU: %@\nMemory: %@";
+"Loading transcription model..." = "Loading transcription model...";
+"Processing audio file for transcription..." = "Processing audio file for transcription...";
+"Transcribing audio..." = "Transcribing audio...";
+"Enhancing transcription with AI..." = "Enhancing transcription with AI...";
+"Transcription completed!" = "Transcription completed!";
 "transcription.enhancementFailedFormat" = "Enhancement failed: %@";
 "transcription.failedFormat" = "Transcription Failed: %@";

--- a/VoiceInk/Services/AudioFileTranscriptionManager.swift
+++ b/VoiceInk/Services/AudioFileTranscriptionManager.swift
@@ -36,15 +36,15 @@ class AudioTranscriptionManager: ObservableObject {
             case .idle:
                 return ""
             case .loading:
-                return "Loading transcription model..."
+                return String(localized: "Loading transcription model...")
             case .processingAudio:
-                return "Processing audio file for transcription..."
+                return String(localized: "Processing audio file for transcription...")
             case .transcribing:
-                return "Transcribing audio..."
+                return String(localized: "Transcribing audio...")
             case .enhancing:
-                return "Enhancing transcription with AI..."
+                return String(localized: "Enhancing transcription with AI...")
             case .completed:
-                return "Transcription completed!"
+                return String(localized: "Transcription completed!")
             }
         }
     }


### PR DESCRIPTION
## Summary
- replace hardcoded transcription progress messages with localized strings
- add English localization entries for the transcription progress messages

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0eec16b58832da1a2a973f1711475