### PR TITLE
Fix optional pointer unwrapping for VAD model

### DIFF
--- a/VoiceInk/Whisper/LibWhisper.swift
+++ b/VoiceInk/Whisper/LibWhisper.swift
@@ -89,7 +89,8 @@ actor WhisperContext {
         if isVADEnabled, let vadModelPath = self.vadModelPath {
             params.vad = true
             vadModelPathCString = Array(vadModelPath.utf8CString)
-            if let pointer: UnsafePointer<CChar> = vadModelPathCString?.withUnsafeBufferPointer({ $0.baseAddress }) {
+            if let vadModelPathCString,
+               let pointer = vadModelPathCString.withUnsafeBufferPointer({ $0.baseAddress }) {
                 params.vad_model_path = pointer
 
                 var vadParams = whisper_vad_default_params()


### PR DESCRIPTION
## Summary
- adjust VAD model pointer handling to unwrap the buffer pointer safely before assigning it to whisper parameters
- keep VAD disabled gracefully when the pointer cannot be prepared

## Testing
- not run (macOS/iOS tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d114ad88c4832d9b10c15e8de40da7